### PR TITLE
handle empty report for GetLatestHelper

### DIFF
--- a/src/helpers/report-helpers.ts
+++ b/src/helpers/report-helpers.ts
@@ -74,6 +74,12 @@ export class ReportHelpers {
     })
 
     const reportId = getReportResponse.data.reports?.[0]?.reportId
+
+    // if we failed to get any report, return empty
+    if (!reportId) {
+      return parse ? [] : ''
+    }
+
     return ReportHelpers.DownloadReport(reportsClient, reportId, { parse })
   }
 


### PR DESCRIPTION
handle empty report for GetLatestHelper so that we don't get an error trying to fetch