### PR TITLE
feat(downloadreport): default to returning an empty report when no reportDocumentId

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
       "url": "https://github.com/josh-fisher"
     },
     {
+      "name": "Kirill Vorobyev",
+      "url": "https://github.com/kirill-vorobyev"
+    },
+    {
       "name": "Sean Clark",
       "url": "https://github.com/optikalefx"
     }

--- a/src/helpers/report-helpers.ts
+++ b/src/helpers/report-helpers.ts
@@ -45,7 +45,9 @@ export class ReportHelpers {
     // ensure we have a document ID
     const reportDocumentId = getReportResponse.data?.reportDocumentId || ''
     if (!reportDocumentId) {
-      throw new Error(`No report for ${reportId}`)
+      // amazon couples the concepts "empty report" and "cancelled report"
+      // we want to default to returning an empty report
+      return []
     }
 
     // fetch the report document


### PR DESCRIPTION
**Changes:**

- DownloadReport will no longer throw when no reportDocumentId
- DownloadReport will default to returning an empty array (empty report) when no reportDocumentId

**Testing:**

use npm link to locally link this branch
run your code which uses download report for a report id which has no data or is reportStatus CANCELLED
see that DownloadReport returns an empty array 🎉 