### PR TITLE
dont sleep for the first check

### DIFF
--- a/src/helpers/feed-helpers.ts
+++ b/src/helpers/feed-helpers.ts
@@ -78,9 +78,6 @@ export class FeedHelpers {
     let attempts = 0
     while (feedStatus !== 'DONE') {
       // eslint-disable-next-line no-await-in-loop
-      await sleep(sleepTime)
-
-      // eslint-disable-next-line no-await-in-loop
       const feedResult = await feedsApiClient.getFeed({
         feedId,
       })
@@ -99,6 +96,12 @@ export class FeedHelpers {
       // prevent infinite while loop
       if (attempts > maxAttempts) {
         throw new Error(`Too many attempts to fetch a DONE response for feed ${feedId}`)
+      }
+
+      // prevent the sleep if we're already finished
+      if (feedStatus !== 'DONE') {
+        // eslint-disable-next-line no-await-in-loop
+        await sleep(sleepTime)
       }
     }
 


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1Zm9ebyPBxNVyLyHihTjKtQ5Y08xxOHI%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=8n8gZQj)
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18EFqSqyY8U1eXOcjOfoUthLSBm7nKVC0%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=R0G2mUM)

don't sleep until after, and conditionally, so we can use this to get fast feed results.