### PR TITLE
feat(downloadreport): decompress gzipped report document

### DIFF
--- a/src/helpers/report-helpers.ts
+++ b/src/helpers/report-helpers.ts
@@ -65,7 +65,7 @@ export class ReportHelpers {
     // amazon sometimes encodes the response as gzip and specifies the compressionAlgorithm
     // we want to decode the data and make this process transparent to the user
     if (documentResponse.data.compressionAlgorithm === 'GZIP') {
-      rawBuffer = await zlib.gunzipSync(contentResponse.data)
+      rawBuffer = zlib.gunzipSync(contentResponse.data)
     }
 
     const rawData = Buffer.from(rawBuffer).toString()

--- a/src/helpers/report-helpers.ts
+++ b/src/helpers/report-helpers.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import zlib from 'zlib'
 
 // eslint-disable-next-line import/no-cycle
 import { ReportsApiClientV20210630 } from '../api-clients/reports-api-client-v20210630'
@@ -56,8 +57,18 @@ export class ReportHelpers {
     })
 
     // fetch the raw content
-    const contentResponse = await axios.get(documentResponse.data.url)
-    const rawData = contentResponse.data
+    const contentResponse = await axios.get(documentResponse.data.url, {
+      responseType: 'arraybuffer',
+    })
+
+    let rawBuffer = contentResponse.data
+    // amazon sometimes encodes the response as gzip and specifies the compressionAlgorithm
+    // we want to decode the data and make this process transparent to the user
+    if (documentResponse.data.compressionAlgorithm === 'GZIP') {
+      rawBuffer = await zlib.gunzipSync(contentResponse.data)
+    }
+
+    const rawData = Buffer.from(rawBuffer).toString()
 
     // optionally parse the results
     if (parse) {


### PR DESCRIPTION
## Changes

- Add zlib to decompress gzipped document response when compressionAlgorithm is `'GZIP'`
- Modify axios request with optional param to set responseType to `'arraybuffer'`
- Add decoding response string from arraybuffer

## Motivation

_Sometimes_ amazon will encode (large?) responses with gzip
![image](https://user-images.githubusercontent.com/35638949/224142786-303e5a0b-e8a4-4218-8695-871838064137.png)
This creates an encoded/compressed gibberish output string unless properly handled with a decoder breaking downstream assumptions and causing false readings of empty reports in our downstream usage of this sdk


## Testing
use npm link to locally link this branch
run your code which uses download report for a report id which is compressed as gzip
see that DownloadReport returns valid data 🎉